### PR TITLE
Change Craigslister#scrape to Craigslister#posts

### DIFF
--- a/lib/craigslister/craigslister.rb
+++ b/lib/craigslister/craigslister.rb
@@ -14,7 +14,7 @@ class Craigslister
     validate_price_range
   end
 
-  def scrape
+  def posts
     LinkScraper.new(url, base_url).posts
   end
 

--- a/spec/craigslister_spec.rb
+++ b/spec/craigslister_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe Craigslister do
     end
   end
 
-  context '#scrape' do
+  context '#posts' do
     it 'scrapes craigslist and returns post objects' do
       scraper = Craigslister.new(item: 'Honda CBR')
-      hondas = scraper.scrape
+      hondas = scraper.posts
 
       expect(hondas.count).to eq(4)
     end


### PR DESCRIPTION
'#posts' is more expressive than '#scrape' because Craigslister returns
post objects.
